### PR TITLE
ci: fix missing solc path issue

### DIFF
--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           wget https://github.com/ethereum/solidity/releases/download/v0.8.19/solc-static-linux
           chmod +x solc-static-linux
-          sudo mv solc-static-linux /usr/local/bin/solc8.10
+          sudo mv solc-static-linux /usr/local/bin/solc
 
       - name: Install node dependencies
         run: |


### PR DESCRIPTION
Otherwise CI will fail to find `solc` in its PATH:
```console
Shared.certoraUtils.CertoraUserInputError: No --solc path given, but default solidity executable solc had an error. Solidity executable solc not found in path
```